### PR TITLE
Fixed error when applying a resampling filter.

### DIFF
--- a/data.py
+++ b/data.py
@@ -2,7 +2,7 @@ import os
 from PIL import Image
 import torchvision.transforms as transforms
 try:
-    from torchvision.transforms import InterpolationMode
+    from transforms import InterpolationMode
     bic = InterpolationMode.BICUBIC
 except ImportError:
     bic = Image.BICUBIC


### PR DESCRIPTION
This fix prevent the following error happening when resizing input image(s) before generating sketches:
ValueError: Unknown resampling filter (InterpolationMode.BICUBIC). Use Image.Resampling.NEAREST (0), Image.Resampling.LANCZOS (1), Image.Resampling.BILINEAR (2), Image.Resampling.BICUBIC (3), Image.Resampling.BOX (4) or Image.Resampling.HAMMING (5)